### PR TITLE
give --version the success exit code

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -129,7 +129,7 @@ int main ( int argc, char** argv )
         if ( ( !strcmp ( argv[i], "--version" ) ) || ( !strcmp ( argv[i], "-v" ) ) )
         {
             qCritical() << qUtf8Printable ( GetVersionAndNameStr ( false ) );
-            exit ( 1 );
+            exit ( 0 );
         }
 
         // Common options:


### PR DESCRIPTION
Change exit code of `jamulus --version` from 1 to 0.

Printing version information as requested is not a failure, so by convention the program should exit with an exit code of 0.
A non-zero exit code would interrupt a shell script following the convention.

- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [ ] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [ ] I've filled all the content above
